### PR TITLE
read query responses displayed as table

### DIFF
--- a/components/Playground.vue
+++ b/components/Playground.vue
@@ -1,5 +1,5 @@
 <template>
-  <div @click.once="init">
+  <div class="playground-component" @click.once="init">
     <div
       class="w-full pt-6 flex items-center flex-col rounded-3xl border-2px-black bg-black overflow-hidden"
     >
@@ -155,11 +155,11 @@ export default {
       } else if (buffer === 'help') {
         this.cls();
         this.printf(messages.help);
+      } else if (buffer === 'clear') {
+        this.cls();
       } else if (!this.ethAddress) {
         this.cls();
         this.printf(messages.warn.connect);
-      } else if (buffer === 'clear') {
-        this.cls();
       } else if (buffer === 'whoami') {
         this.cls();
         this.printf(this.ethAddress);

--- a/store/index.ts
+++ b/store/index.ts
@@ -37,6 +37,11 @@ window.tableland = 'First connect with metamask, then start building web3 with S
 const getConnection = function () {
   let connection: any;
   return async function (options?: any) {
+    if (options?.disconnect) {
+      connection = void 0;
+      delete window.tableland;
+      return;
+    }
     if (connection) return connection;
 
     console.log(`connecting to validator at: ${process.env.validatorHost}`);
@@ -58,6 +63,9 @@ export const actions: ActionTree<RootState, RootState> = {
     const ethAddress = await tableland.signer.getAddress();
     // save the user's eth account address
     context.commit('set', {key: 'ethAddress', value: ethAddress});
+  },
+  disconnect: async function (context) {
+    await getConnection({disconnect: true});
   },
   runSql: async function (context, query) {
     const tableland = await getConnection();

--- a/test/Playground.spec.js
+++ b/test/Playground.spec.js
@@ -14,6 +14,12 @@ import {
   actions
 } from '../store/index.ts';
 
+const wait = function (ms) {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(void 0), ms);
+  });
+}
+
 describe('Playground component', function () {
   setupTest({
     configFile: 'nuxt.config.js'
@@ -33,8 +39,14 @@ describe('Playground component', function () {
       actions: actions
     });
 
+    await store.dispatch('disconnect');
+
     // hoisted
-    wrapper = mount(Playground, { localVue: localVue, mocks: { $store: store }});
+    wrapper = mount(Playground, {
+      attachTo: document.body,
+      localVue: localVue,
+      mocks: { $store: store }
+    });
   });
 
   test('is a Vue instance', function () {
@@ -72,6 +84,53 @@ describe('Playground component', function () {
     }
   });
 
+  test('Shows docs message', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'docs';
+    form.trigger('submit');
+
+    await flushPromises();
+
+    const messageLines = messages.docs.split('\n');
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+
+    for (let i = 0; i < messageLines.length; i++) {
+      const line = messageLines[i];
+
+      await expect(terminalLines.at(i).text().replace(/\s+/g, '')).toMatch(messageLines[i].replace(/\s+/g, ''));
+    }
+  });
+
+  test('clear clears the terminal screen', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'help';
+    form.trigger('submit');
+
+    await flushPromises();
+
+    const terminalLines1 = wrapper.findAll('.web-terminal > span');
+    await expect(terminalLines1.at(0).text()).toMatch('Available commands:');
+
+    textInput.element.value = 'clear';
+    form.trigger('submit');
+
+    await wait(1001);
+    await flushPromises();
+
+    const terminalLines2 = wrapper.findAll('.web-terminal > span');
+
+    // NOTES:
+    //    - the clear command clears enough lines to make sure no old commands are visible.
+    //      Since the wrapper doesn't have a clientHeight like a real DOM, clear is only
+    //      going to clear one line.
+    //    - can't use toMatch for empty string
+    await expect(terminalLines2.at(0).text() === '').toBe(true);
+  });
+
   test('Shows help message when connection successful', async function () {
     const form = wrapper.find('form.web-terminal-form');
     const textInput = form.find('input[type="text"]');
@@ -81,9 +140,7 @@ describe('Playground component', function () {
 
     // mock connect waits 500ms, we want to make sure we wait longer than that.
     // This allows the Component to render the connnecting spinner
-    await new Promise(resolve => {
-      setTimeout(() => resolve(void 0), 1500);
-    });
+    await wait(1500);
     await flushPromises();
 
     const messageLines = messages.connected.split('\n');
@@ -94,6 +151,290 @@ describe('Playground component', function () {
 
       await expect(terminalLines.at(i).text().replace(/\s+/g, '')).toMatch(messageLines[i].replace(/\s+/g, ''));
     }
+  });
+
+  test('whoami shows eth address', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    // This allows the Component to render the connnecting spinner
+    await wait(1500);
+    await flushPromises();
+
+    textInput.element.value = 'whoami';
+    form.trigger('submit');
+
+    await flushPromises();
+
+    await expect(wrapper.find('.web-terminal > span').text() === 'testaddress').toBe(true);
+  });
+
+  // TODO: this test only passes if its the first call to connect because the module cache isn't being cleared
+  test('Shows discord message when address not authorized', async function () {
+    nextError(new Error('checking address authorization: address not authorized'));
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    const messageLines = messages.warn.address.split('\n');
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+
+    for (let i = 0; i < messageLines.length; i++) {
+      const line = messageLines[i];
+
+      await expect(terminalLines.at(i).text().replace(/\s+/g, '')).toMatch(messageLines[i].replace(/\s+/g, ''));
+    }
+  });
+
+  test('prints a table with read query results', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    textInput.element.value = 'readquery1';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    await expect(wrapper.findAll('th').at(0)).toBeTruthy();
+    await expect(wrapper.findAll('th').at(1)).toBeTruthy();
+    await expect(wrapper.findAll('th').at(2)).toBeTruthy();
+  });
+
+  test('create table statements show queryable name', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    textInput.element.value = 'create table unittests (a int);';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+    await expect(terminalLines.at(0).text()).toMatch('Table Created:');
+    await expect(terminalLines.at(1).text()).toMatch('{');
+    await expect(terminalLines.at(2).text()).toMatch('"name": "unittests_180');
+    await expect(terminalLines.at(3).text()).toMatch('}');
+  });
+
+  test('list show user their existing tables', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    textInput.element.value = 'list';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+    await expect(terminalLines.at(0).text()).toMatch('Result:');
+    await expect(terminalLines.at(1).text()).toMatch('[');
+    await expect(terminalLines.at(2).text()).toMatch('{');
+    await expect(terminalLines.at(3).text()).toMatch('"controller": "0x03cA05928aC3179c20Ae6541376Fd6B6E6ed92Cd",');
+  });
+
+  test('user commands are buffered and saved in command history', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    // mimic user typing and hitting return twice
+    textInput.element.value = 'qwe';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    textInput.element.value = 'rty';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    // hitting up twice should show the first command
+    textInput.trigger('keydown.up');
+    await wait(1);
+    await flushPromises();
+    textInput.trigger('keydown.up');
+    await wait(1);
+    await flushPromises();
+
+    await expect(textInput.element.value === 'qwe').toBe(true);
+
+    // now hitting down should show the second command
+    textInput.trigger('keydown.down');
+    await wait(1);
+    await flushPromises();
+
+    await expect(textInput.element.value === 'rty').toBe(true);
+
+  });
+
+  test('clicking the terminal puts focus on input', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+    const playgroundComponent = wrapper.find('.playground-component');
+
+    await expect(textInput.element).not.toBe(document.activeElement);
+
+    playgroundComponent.trigger('click');
+    await wait(1);
+    await flushPromises();
+
+    await expect(textInput.element).toBe(document.activeElement);
+  });
+
+  test('submitting empty string shows warning', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    textInput.element.value = '';
+    form.trigger('submit');
+    await flushPromises();
+
+    const messageLines = messages.warn.statement.split('\n');
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+
+    for (let i = 0; i < messageLines.length; i++) {
+      const line = messageLines[i];
+
+      await expect(terminalLines.at(i).text().replace(/\s+/g, '')).toMatch(messageLines[i].replace(/\s+/g, ''));
+    }
+  });
+
+  test('read query errors are shown', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    nextError(new Error('test error'));
+
+    textInput.element.value = 'readquery1';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+    await expect(terminalLines.at(0).text()).toMatch('Error:');
+    await expect(terminalLines.at(1).text()).toMatch('test error');
+  });
+
+  test('update query shows rpc response', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    textInput.element.value = 'updatequery1';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+    await expect(terminalLines.at(0).text()).toMatch('Result:');
+    await expect(terminalLines.at(1).text()).toMatch('{');
+    await expect(terminalLines.at(2).text()).toMatch('"data": null');
+    await expect(terminalLines.at(3).text()).toMatch('}');
+  });
+
+  test('create query errors are shown', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    nextError(new Error('test error'));
+
+    textInput.element.value = 'create table unittests (a int);';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+    await expect(terminalLines.at(0).text()).toMatch('Error:');
+    await expect(terminalLines.at(1).text()).toMatch('test error');
+  });
+
+  test('list errors are shown', async function () {
+    const form = wrapper.find('form.web-terminal-form');
+    const textInput = form.find('input[type="text"]');
+
+    textInput.element.value = 'connect';
+    form.trigger('submit');
+
+    // mock connect waits 500ms, we want to make sure we wait longer than that.
+    await wait(1000);
+    await flushPromises();
+
+    nextError(new Error('test error'));
+
+    textInput.element.value = 'list';
+    form.trigger('submit');
+
+    await wait(1);
+    await flushPromises();
+
+    const terminalLines = wrapper.findAll('.web-terminal > span');
+    await expect(terminalLines.at(0).text()).toMatch('Error:');
+    await expect(terminalLines.at(1).text()).toMatch('test error');
   });
 
 });

--- a/test/__snapshots__/PageIndex.spec.js.snap
+++ b/test/__snapshots__/PageIndex.spec.js.snap
@@ -283,7 +283,9 @@ exports[`Index Page renders correctly 1`] = `
           
           </p>
            
-          <div>
+          <div
+            class="playground-component"
+          >
             <div
               class="w-full pt-6 flex items-center flex-col rounded-3xl border-2px-black bg-black overflow-hidden"
             >

--- a/test/mock_modules/tableland.js
+++ b/test/mock_modules/tableland.js
@@ -5,7 +5,7 @@ module.exports = {
     await new Promise(resolve => {
       setTimeout(() => resolve(void 0), 500);
     });
-console.log(testErr);
+
     if (testErr) {
       const err = testErr;
       testErr = null;
@@ -21,9 +21,104 @@ console.log(testErr);
           return 'testaddress';
         }
       },
-      list: async function () {},
-      query: async function () {},
-      create: async function () {}
+      list: async function () {
+        if (testErr) {
+          const err = testErr;
+          testErr = null;
+          throw err;
+        }
+
+        return [
+          {
+            "controller": "0x03cA05928aC3179c20Ae6541376Fd6B6E6ed92Cd",
+            "name": "brave_joe_87",
+            "description": "",
+            "structure": "ef7be01282ea97380e4d3bbcba6774cbc7242c46ee51b7e611f1efdfa3623e53",
+            "created_at": "2022-02-17T19:18:47.213148Z"
+          },
+          {
+            "controller": "0x03cA05928aC3179c20Ae6541376Fd6B6E6ed92Cd",
+            "name": "brave_joe_1112_88",
+            "description": "",
+            "structure": "ef7be01282ea97380e4d3bbcba6774cbc7242c46ee51b7e611f1efdfa3623e53",
+            "created_at": "2022-02-17T19:31:41.76724Z"
+          },
+          {
+            "controller": "0x03cA05928aC3179c20Ae6541376Fd6B6E6ed92Cd",
+            "name": "todo_app_example__03ca0592_89",
+            "description": "",
+            "structure": "7837fa79ed5151d99da5051b41d7387e7c249a2b0321d440138c81108160cdd9",
+            "created_at": "2022-02-17T19:33:16.702406Z"
+          }
+        ];
+      },
+      query: async function (query) {
+        if (testErr) {
+          const err = testErr;
+          testErr = null;
+          throw err;
+        }
+
+        if (query === 'readquery1') {
+          return {
+            data: {
+                columns: [
+                    {
+                        name: 'complete'
+                    },
+                    {
+                        name: 'name'
+                    },
+                    {
+                        name: 'deleted'
+                    },
+                    {
+                        name: 'id'
+                    }
+                ],
+                rows: [
+                    [
+                        false,
+                        'Explore Tableland',
+                        false,
+                        1
+                    ],
+                    [
+                        false,
+                        'Join Tableland Discord',
+                        false,
+                        2
+                    ],
+                    [
+                        false,
+                        'Build web3 with SQL!',
+                        false,
+                        3
+                    ]
+                ]
+            }
+          };
+        }
+
+        if (query === 'updatequery1') {
+          return {
+            data: null
+          };
+        }
+
+        return {};
+      },
+      create: async function () {
+        if (testErr) {
+          const err = testErr;
+          testErr = null;
+          throw err;
+        }
+
+        return {
+            name: "unittests_180"
+        };
+      }
     };
   },
   nextError: function (err) {


### PR DESCRIPTION
Read query responses are formatted as simple tables.  Any feedback or ideas on design/style changes are very welcome.
This is the deliverable for this: 
https://www.notion.so/textile/Display-query-results-as-table-in-demo-console-2c209d94cdf8429daf68ef0e70717a98