### PR TITLE
Add network env variable to allow use on staging

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,8 @@
 export default {
   env: {
     // http://localhost:8545
-    validatorHost: process.env.VALIDATOR || 'https://testnet.tableland.network'
+    validatorHost: process.env.VALIDATOR || 'https://testnet.tableland.network',
+    validatorNet: process.env.NETWORK || 'testnet'
   },
   // Disable server-side rendering: https://go.nuxtjs.dev/ssr-mode
   ssr: false,

--- a/store/index.ts
+++ b/store/index.ts
@@ -46,7 +46,8 @@ const getConnection = function () {
 
     console.log(`connecting to validator at: ${process.env.validatorHost}`);
     connection = await connect({
-      host: process.env.validatorHost as string
+      host: process.env.validatorHost as string,
+      network: process.env.validatorNet as string
     });
 
     window.tableland = connection;


### PR DESCRIPTION
This lets us use the site with the staging network, in case we want to test something there.
This will also be needed once we move to mainnet