### PR TITLE
Update UI claim allowance if you bought secondary

### DIFF
--- a/pages/mint-rigs.vue
+++ b/pages/mint-rigs.vue
@@ -42,7 +42,7 @@
           </h1>
         </div>
         <div
-          v-else-if="paidAllowance + freeAllowance - tokens.length > 0"
+          v-else-if="paidAllowance + freeAllowance > 0"
           class="w-full md:w-full lg:w-1/2 xl:w-1/2 px-6 pb-0 lg:pb-0 pt-0"
         >
           <h1


### PR DESCRIPTION
Some people had purchased on the secondary market before they realized they were on the allowlist.  This update will show the mint form even if you already own rigs.  It also adds a message informing people that if they mint more than they are allowed, the contract will refund their ETH