### PR TITLE
add claims handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@alch/alchemy-web3": "^1.4.4",
         "@chenfengyuan/vue-countdown": "^1.1.5",
-        "@tableland/rigs": "^0.0.1",
+        "@tableland/rigs": "^0.0.2",
         "@tableland/sdk": "^2.0.2",
         "@walletconnect/web3-provider": "^1.7.8",
         "aos": "^2.3.4",
@@ -4698,8 +4698,9 @@
       }
     },
     "node_modules/@tableland/rigs": {
-      "version": "0.0.1",
-      "license": "Unlicense",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.0.2.tgz",
+      "integrity": "sha512-yRmV8sMPvgMlj8ILLp2qKSFSXnRVegEiGOTZr+yQP7aZvXxcQw4pR3FDXXhMid7K4bB8ZseWv0DtmpPan2zsbA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -30017,7 +30018,9 @@
       "version": "2.0.2"
     },
     "@tableland/rigs": {
-      "version": "0.0.1"
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.0.2.tgz",
+      "integrity": "sha512-yRmV8sMPvgMlj8ILLp2qKSFSXnRVegEiGOTZr+yQP7aZvXxcQw4pR3FDXXhMid7K4bB8ZseWv0DtmpPan2zsbA=="
     },
     "@tableland/sdk": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@alch/alchemy-web3": "^1.4.4",
     "@chenfengyuan/vue-countdown": "^1.1.5",
-    "@tableland/rigs": "^0.0.1",
+    "@tableland/rigs": "^0.0.2",
     "@tableland/sdk": "^2.0.2",
     "@walletconnect/web3-provider": "^1.7.8",
     "aos": "^2.3.4",

--- a/pages/mint-rigs.vue
+++ b/pages/mint-rigs.vue
@@ -61,6 +61,29 @@
           </h1>
         </div>
 
+        <!-- Sold out screen -->
+        <div
+          v-else-if="supply === 0"
+          class="w-full md:w-full lg:w-1/2 xl:w-1/2 px-6 pb-0 lg:pb-0 pt-0"
+        >
+          <h1
+            class="text-white w-full h-auto text-xl md:text-2xl xl:text-2xl leading-tighter mb-10 lg:mb-18"
+          >
+            Each Rig is generated from 1,074 handcrafted works of art for the
+            builders and creatives of cyberspace. It's time to grab yours.
+          </h1>
+          <h1
+            class="text-white w-full h-auto text-xl md:text-2xl xl:text-2xl leading-tighter mb-10 lg:mb-18"
+          >
+            Hey Tablelander! Looks like Rigs is sold out :( Check them out on
+            <a
+              href="https://opensea.io/collection/tableland-rigs"
+              target="_blank"
+              >OpenSea</a
+            >.
+          </h1>
+        </div>
+
         <!-- Public mint phase screen -->
         <div
           v-else-if="mintphase === 3"
@@ -73,22 +96,10 @@
             builders and creatives of cyberspace. It's time to grab yours.
           </h1>
           <h1
-            v-if="supply > 0"
             class="text-white w-full h-auto text-xl md:text-2xl xl:text-2xl leading-tighter mb-10 lg:mb-18"
           >
-            Hey Tablelander! Looks like there are {{ supply }} tokens left to
+            Hey Tablelander! Looks like there are {{ supply }} Rigs left to
             mint.
-          </h1>
-          <h1
-            v-else
-            class="text-white w-full h-auto text-xl md:text-2xl xl:text-2xl leading-tighter mb-10 lg:mb-18"
-          >
-            Hey Tablelander! Looks like Rigs is sold out :( Check them out on
-            <a
-              href="https://opensea.io/collection/tableland-rigs"
-              target="_blank"
-              >OpenSea</a
-            >.
           </h1>
         </div>
 
@@ -104,9 +115,18 @@
             builders and creatives of cyberspace. It's time to grab yours.
           </h1>
           <h1
+            v-if="mintphase === 2 && claimed.allowClaims > 0"
             class="text-white w-full h-auto text-xl md:text-2xl xl:text-2xl leading-tighter mb-10 lg:mb-18"
           >
-            Hey Tablelander! Looks like you can grab a total of
+            Hey Tablelander! Looks like you already minted during the allowlist
+            phase.
+          </h1>
+          <h1
+            v-else
+            class="text-white w-full h-auto text-xl md:text-2xl xl:text-2xl leading-tighter mb-10 lg:mb-18"
+          >
+            Hey Tablelander! There are {{ supply }} Rigs left to mint. Looks
+            like you can grab a total of
             {{ paidAllowance + freeAllowance }} Rig(s) for 0.05E each + gas. If
             you try to mint more than your total allowance you will
             automatically be refunded.
@@ -159,9 +179,12 @@
           ></a>
           <div
             v-else-if="
-              (mintphase === 1 && paidAllowance + freeAllowance > 0) ||
-              (mintphase === 2 && paidAllowance + freeAllowance > 0) ||
-              mintphase === 3
+              supply > 0 &&
+              ((mintphase === 1 && paidAllowance + freeAllowance > 0) ||
+                (mintphase === 2 &&
+                  paidAllowance + freeAllowance > 0 &&
+                  claimed.allowClaims === 0) ||
+                mintphase === 3)
             "
           >
             <a class="btn bg-black text-white" @click="mint">
@@ -239,6 +262,7 @@ export default {
       freeAllowance: 0,
       paidAllowance: 0,
       proof: [],
+      claimed: { allowClaims: 0, waitClaims: 0 },
       rigs: [],
       nav: [
         {
@@ -319,6 +343,7 @@ export default {
         this.proof = status.proof || [];
         this.tokens = status.tokens || [];
         this.supply = status.supply || 0;
+        this.claimed = status.claimed || { allowClaims: 0, waitClaims: 0 };
 
         this.rigs = await this.$store.dispatch("getRigsMetadata", {
           tokens: this.tokens,


### PR DESCRIPTION
Since we now expose number of claimed rigs, we can warn about the fact that you can't mint during whitelist if you minted during allowlist. Could be even nicer to avoid the refund warning since we now know how many they can mint, but didn't want to change too much at this late hour.