### PR TITLE
fix #66 correct sql in terminal help output

### DIFF
--- a/playground-messages.js
+++ b/playground-messages.js
@@ -21,7 +21,7 @@ export default {
     "    SELECT * FROM mytable_5_30 WHERE id = 0;\n" +
     "Example Create and Write Queries:\n" +
     "    CREATE TABLE trees (climate TEXT, name TEXT);\n" +
-    "    INSERT INTO trees_5_<tableId> ('climate', 'name') VALUES ('cold', 'aspen');",
+    "    INSERT INTO trees_5_<tableId> (climate, name) VALUES ('cold', 'aspen');",
   running: "Running SQL on the Validator",
   warn: {
     address:

--- a/test/__snapshots__/PageIndex.spec.js.snap
+++ b/test/__snapshots__/PageIndex.spec.js.snap
@@ -712,7 +712,7 @@ exports[`Index Page renders correctly when browser does not have a wallet 1`] = 
                     </span>
                     <span>
                       
-                INSERT INTO trees_5_&lt;tableId&gt; ('climate', 'name') VALUES ('cold', 'aspen');
+                INSERT INTO trees_5_&lt;tableId&gt; (climate, name) VALUES ('cold', 'aspen');
             
                       <br />
                        
@@ -1669,7 +1669,7 @@ exports[`Index Page renders correctly when browser has a wallet 1`] = `
                     </span>
                     <span>
                       
-                INSERT INTO trees_5_&lt;tableId&gt; ('climate', 'name') VALUES ('cold', 'aspen');
+                INSERT INTO trees_5_&lt;tableId&gt; (climate, name) VALUES ('cold', 'aspen');
             
                       <br />
                        


### PR DESCRIPTION
The column names in the example table create statement where quoted, which is not correct SQL