### PR TITLE
Fix terminal create table with prefix issue

### DIFF
--- a/store/index.ts
+++ b/store/index.ts
@@ -300,7 +300,7 @@ export const actions: ActionTree<RootState, RootState> = {
     );
 
     const tableland = await getConnection();
-    return await tableland.create(definition, tableName);
+    return await tableland.create(definition, { prefix: tableName });
   },
   myTables: async function (context) {
     const tableland = await getConnection();


### PR DESCRIPTION
@awmuncy and I looked at this and the only bug we could find in the terminal is that the create table statements are not correctly assigning the table name prefix in the call to the SDK.  

There is a larger issue that captures the work of upgrading the SDK to v4, but that will have to be coordinated with the rigs package.
 https://github.com/tablelandnetwork/site-tableland/issues/125