### PR TITLE
feat: update link to docs 'Why SQLite?' page

### DIFF
--- a/lib/features.ts
+++ b/lib/features.ts
@@ -7,7 +7,7 @@ const features: Feature[] = [
     icon: FaDatabase,
     description:
       "Tableland is a fully-featured, ACID-compliant, relational database built on the blazing-fast SQLite engine.",
-    link: "https://docs.tableland.xyz/playbooks",
+    link: "https://docs.tableland.xyz/fundamentals/why-sqlite",
   },
   {
     title: "On-chain security",


### PR DESCRIPTION
Updates the homepage landing to point to the "Why SQLite?" docs page instead of the existing SQL playbooks docs page: https://docs.tableland.xyz/fundamentals/why-sqlite
![Screen Shot 2023-05-23 at 12 22 47 PM](https://github.com/tablelandnetwork/site-tableland/assets/13358940/68f9b757-0a51-4bfe-8a24-fc02f88650c0)